### PR TITLE
Add Freerouting JAR version 1.4.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # freerouting-jar
-Freerouting dependency for eurorack-blocks. ⚠️ Don't clone or add as a submodule ⚠️
+
+⚠️ Do not clone this repository or add it as a submodule. We could modify it whenever we see fit ⚠️
+
+This repository is a mirror of the [Freerouting JAR](https://github.com/freerouting/freerouting/releases).
+
+It is meant only to be used as a dependency for the
+[`eurorack-blocks`](https://github.com/ohmtech-rdi/eurorack-blocks) project.
+
+This repository is not the official Freerouting repository. It exists only because Freerouting
+doesn't provide a repository for their releases, and including it as a submodule of the
+[`eurorack-blocks`](https://github.com/ohmtech-rdi/eurorack-blocks) project simplifies
+installation and automations.
+
+Always refer to the official source. This repository is currently using
+[version 1.4.5.1](https://github.com/freerouting/freerouting/releases/tag/v1.4.5.1) of the Freerouting JAR.


### PR DESCRIPTION
This PR adds [Freerouting JAR version 1.4.5.1](https://github.com/freerouting/freerouting/releases/download/v1.4.5.1/freerouting-1.4.5.1.jar).